### PR TITLE
Simplify Heroku deploy for new users

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn lf_kiosk.wsgi --log-file -
+release: python manage.py migrate --no-input

--- a/app.json
+++ b/app.json
@@ -13,5 +13,8 @@
   "website": "http://bulletin.lftechnology.com/",
   "repository": "https://github.com/leapfrogtechnology/LF-Bulletin-board/tree/master",
   "logo": "http://lftechnology.com/media/images/top_mast_logo.png",
-  "success_url": "/"
+  "success_url": "/",
+  "addons": [
+    "heroku-postgresql"
+  ]
 }

--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
   "website": "http://bulletin.lftechnology.com/",
   "repository": "https://github.com/leapfrogtechnology/LF-Bulletin-board/tree/master",
   "logo": "http://lftechnology.com/media/images/top_mast_logo.png",
-  "success_url": "/",
+  "success_url": "/admin",
   "addons": [
     "heroku-postgresql"
   ]

--- a/lf_kiosk/settings.py
+++ b/lf_kiosk/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -77,21 +78,27 @@ WSGI_APPLICATION = 'lf_kiosk.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        # Configuration for SQLite Database
-        # 'ENGINE': 'django.db.backends.sqlite3',
-        # 'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+DATABASES = {}
+if 'DATABASE_URL' in os.environ:
+    DATABASES['default'] = dj_database_url.config(conn_max_age=600, ssl_require=True)
+else:
+    DATABASES = {
+        'default': {
+            # Configuration for SQLite Database
+            # 'ENGINE': 'django.db.backends.sqlite3',
+            # 'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
 
-        # Configuration for Postgres database
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': os.environ.get('DB_NAME'),
-        'USER': os.environ.get('DB_USER'),
-        'PASSWORD': os.environ.get('DB_PASSWORD'),
-        'HOST': os.environ.get('DB_HOST'),
-        'PORT': os.environ.get('DB_PORT'),
+            # Configuration for Postgres database
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': os.environ.get('DB_NAME'),
+            'USER': os.environ.get('DB_USER'),
+            'PASSWORD': os.environ.get('DB_PASSWORD'),
+            'HOST': os.environ.get('DB_HOST'),
+            'PORT': os.environ.get('DB_PORT'),
+        }
     }
-}
+
+
 
 
 # Password validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.9
 gunicorn==19.6.0
 psycopg2==2.7.1
+dj-database-url==0.5.0


### PR DESCRIPTION
Hi there, just thought I'd make a few tweaks to make the Heroku deploy simpler for people wanting to use this.

This PR...

- removes need to manually add a database after first deploy (uses free heroku postgres)
- removes need to manually configure database after first deploy
- removes need to manually migrate database
- changes the first page after initial deploy to `/admin` instead of `/`

Note that running `heroku run python manage.py createsuperuser` is still required because the deployer should set their own custom username and password for security.