### PR TITLE
LE-274: Show User Image Instead of name in Bulletin dashboard

### DIFF
--- a/app/src/components/dashboard/SideMenu.js
+++ b/app/src/components/dashboard/SideMenu.js
@@ -17,6 +17,10 @@ class SideMenu extends Component {
     };
   }
 
+  getUserImage() {
+    return this.props.user && this.props.user.imageUrl ? this.props.user.imageUrl : null;
+  }
+
   render() {
     return (
       <div>
@@ -25,7 +29,11 @@ class SideMenu extends Component {
         </div>
         <ul className="side-menu-list">
           <li>
-            <span className="profile-name">{this.state.userInitials}</span>
+            {this.getUserImage() ? (
+              <img src={this.getUserImage()} alt={this.state.userInitials} className="circular-img" />
+            ) : (
+              <span className="profile-name">{this.state.userInitials}</span>
+            )}
           </li>
           <li>
             <MoreMenu />

--- a/app/src/components/moreMenu/index.js
+++ b/app/src/components/moreMenu/index.js
@@ -47,7 +47,10 @@ class MoreMenu extends Component {
           this.dropDownMenu = element;
         }}
       >
-        <span onClick={event => this.showMenu(event)}>
+        <span
+          onClick={event => this.showMenu(event)}
+          style={{ paddingLeft: 20, paddingRight: 20, paddingTop: 10, paddingBottom: 10 }}
+        >
           <i className="icon ion-md-more"></i>
         </span>
         {this.state.showMenu ? (

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -422,6 +422,13 @@ img.bulletin-logo-big {
   display: block;
 }
 
+.circular-img {
+  border-radius: 50%;
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+}
+
 /*-----Toggle button style for active/inactive status-------*/
 
 .switch {


### PR DESCRIPTION
In the image below the bottom left the image given by google is shown, if image is not found then fallback our previous default image is shown

![Screenshot from 2020-01-15 17-45-18](https://user-images.githubusercontent.com/15843175/72432312-d845fa00-37be-11ea-84bd-4f7d41157534.png)
