### PR TITLE
LE-283: Slides when changing from one slide to another previous slide was still seen

### DIFF
--- a/app/src/components/bulletinScreen/index.js
+++ b/app/src/components/bulletinScreen/index.js
@@ -284,23 +284,21 @@ class BulletinScreen extends Component {
    * @memberof BulletinScreen
    */
   getLink(link, visibility) {
-    if (link) {
-      if (visibility || this.state.startSecondSlide) {
-        if (link.search('docs.google.com') > -1) {
-          if (link.includes('start=false')) {
-            link = link.replace('start=false', 'start=true');
-          }
-        } else if (link.match(regex.YOUTUBE_REGEX) !== null) {
-          if (link.includes('autoplay=0')) {
-            link = link.replace('autoplay=0', 'autoplay=1');
-          }
-          if (link.includes('mute=0')) {
-            link = link.replace('mute=0', 'mute=1');
-          }
+    if (link && (visibility || this.state.startSecondSlide)) {
+      if (link.search('docs.google.com') > -1) {
+        if (link.includes('start=false')) {
+          link = link.replace('start=false', 'start=true');
         }
-      } else {
-        link = '';
+      } else if (link.match(regex.YOUTUBE_REGEX) !== null) {
+        if (link.includes('autoplay=0')) {
+          link = link.replace('autoplay=0', 'autoplay=1');
+        }
+        if (link.includes('mute=0')) {
+          link = link.replace('mute=0', 'mute=1');
+        }
       }
+    } else {
+      link = '';
     }
 
     return link;

--- a/app/src/components/bulletinScreen/index.js
+++ b/app/src/components/bulletinScreen/index.js
@@ -285,21 +285,6 @@ class BulletinScreen extends Component {
    */
   getLink(link, visibility) {
     if (link) {
-      if (!visibility) {
-        if (link.search('docs.google.com') > -1) {
-          if (link.includes('start=true')) {
-            link = link.replace('start=true', 'start=false');
-          }
-        } else if (link.match(regex.YOUTUBE_REGEX) !== null) {
-          if (link.includes('autoplay=1')) {
-            link = link.replace('autoplay=1', 'autoplay=0');
-          }
-          if (link.includes('mute=1')) {
-            link = link.replace('mute=1', 'mute=0');
-          }
-        }
-      }
-
       if (visibility || this.state.startSecondSlide) {
         if (link.search('docs.google.com') > -1) {
           if (link.includes('start=false')) {
@@ -313,6 +298,8 @@ class BulletinScreen extends Component {
             link = link.replace('mute=0', 'mute=1');
           }
         }
+      } else {
+        link = '';
       }
     }
 


### PR DESCRIPTION
If we have 4 slides, currently bulletin board has got two iframes. One shows the slides while other is hidden and fetching data for easy transition from one slide to another. 

If slide 1 and slide 2 are currently on pipelines, slide 1 is shown and slide 2 is hidden when slide 1 has ended slide 2 turn comes and slide 3 is in pipeline.
But slide 1 is shown when transiting from slide 2 to slide 3.