### PR TITLE
LE-292: API crash on Bulletin Max Priority Fetch and Refresh Token not being saved

### DIFF
--- a/api/src/migrations/20200227203813_increase_refresh_token_column_size.js
+++ b/api/src/migrations/20200227203813_increase_refresh_token_column_size.js
@@ -1,0 +1,19 @@
+/**
+ * @param  {object} knex
+ * @returns {Promise}
+ */
+export function up(knex) {
+  return knex.schema.table('sessions', table => {
+    table.string('refresh_token', 1000).alter();
+  });
+}
+
+/**
+ * @param  {object} knex
+ * @returns {Promise}
+ */
+export function down(knex) {
+  return knex.schema.table('sessions', table => {
+    table.string('refresh_token').alter();
+  });
+}

--- a/api/src/services/bulletinService.js
+++ b/api/src/services/bulletinService.js
@@ -1,6 +1,8 @@
 import Boom from 'boom';
-import Bulletin from '../models/bulletin';
+
 import Bookshelf from '../db';
+import knexConfig from '../knexfile';
+import Bulletin from '../models/bulletin';
 
 /**
  * Get all bulletins.
@@ -34,8 +36,7 @@ export function getBulletin(id) {
  * @returns {Promise}
  */
 export async function createBulletin(bulletin) {
-  const model = await getMaxPriorityValue();
-  const newPriority = model.get('maxPriority') + 1;
+  const newPriority = await getMaxPriorityValue();
 
   return new Bulletin({
     title: bulletin.title,
@@ -120,6 +121,17 @@ export function deleteBulletin(id) {
  *
  * @returns
  */
-function getMaxPriorityValue() {
-  return Bulletin.query('max', 'priority').fetch();
+async function getMaxPriorityValue() {
+  const query = await Bulletin.query('max', 'priority').fetch();
+  const { client } = knexConfig;
+
+  let newPriority = 1;
+
+  if (client === 'pg') {
+    newPriority = query.get('max');
+  } else {
+    newPriority = query.get('maxPriority');
+  }
+
+  return newPriority + 1;
 }

--- a/api/src/services/bulletinService.js
+++ b/api/src/services/bulletinService.js
@@ -35,7 +35,7 @@ export function getBulletin(id) {
  */
 export async function createBulletin(bulletin) {
   const model = await getMaxPriorityValue();
-  const newPriority = model.get('priority') + 1;
+  const newPriority = model.get('maxPriority') + 1;
 
   return new Bulletin({
     title: bulletin.title,
@@ -121,5 +121,5 @@ export function deleteBulletin(id) {
  * @returns
  */
 function getMaxPriorityValue() {
-  return Bulletin.query('max', 'priority').fetch({ columns: ['priority'] });
+  return Bulletin.query('max', 'priority').fetch();
 }


### PR DESCRIPTION
Due to the previous implementation of SQL-lite and implementations of databases when saving refresh token to session table the data can't be saved due to size limitation.

Error Occurred Screenshot:
![Screenshot from 2020-02-27 20-31-17](https://user-images.githubusercontent.com/15843175/75460732-eedc9500-59a9-11ea-9641-209fa732f08d.png)


Also due to the database and their query changes per database implementation when fetching maxPriotity of bulletin the API would crash. Max Priority data is now fetched based on database type. 

Also Fixed a condition when if there are no bulletins in database, API would crash.