### PR TITLE
LE-293: Show Admin Panel Navigation only to Super Admin and Highlight Side menu for active link

### DIFF
--- a/app/src/components/dashboard/SideMenu.js
+++ b/app/src/components/dashboard/SideMenu.js
@@ -1,12 +1,12 @@
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import React, { Component } from 'react';
+import { NavLink } from 'react-router-dom';
 
 import MoreMenu from '../moreMenu';
 
-import logo from '../../assets/images/bulletin-logo-inverse.png';
-import screenIcon from '../../assets/images/screen_icon.svg';
 import userIcon from '../../assets/images/user_icon.svg';
+import screenIcon from '../../assets/images/screen_icon.svg';
+import logo from '../../assets/images/bulletin-logo-inverse.png';
 
 class SideMenu extends Component {
   constructor(props) {
@@ -26,23 +26,26 @@ class SideMenu extends Component {
   }
 
   render() {
+    const { role: userRole } = this.props.user;
+
     return (
       <div className="sidemenu-container">
         <div className="sidemenu-bulletin-logo">
           <img src={logo} alt="bulletin logo" />
         </div>
-        <Link to="/dashboard/list">
+        <NavLink activeClassName="sidemenu-icons-active" to="/dashboard/list">
           <div className="sidemenu-icons">
             <img src={screenIcon} alt="Screen" />
           </div>
-        </Link>
+        </NavLink>
 
-        <Link to="/dashboard/admin">
-          <div className="sidemenu-icons">
-            <img src={userIcon} alt="User" />
-          </div>
-        </Link>
-
+        {userRole && userRole === 'super_admin' && (
+          <NavLink activeClassName="sidemenu-icons-active" to="/dashboard/admin">
+            <div className="sidemenu-icons">
+              <img src={userIcon} alt="User" />
+            </div>
+          </NavLink>
+        )}
         <div className="side-menu-list">
           <div>
             {this.getUserImage() ? (

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -415,7 +415,8 @@ body {
   -webkit-transition: background 0.3s ease-in-out;
 }
 
-.sidemenu-icons:hover {
+.sidemenu-icons:hover,
+.sidemenu-icons-active {
   background: rgba(255, 255, 255, 0.17);
 }
 


### PR DESCRIPTION
Side menu navigations show user one which navigation is the user currently on.

If the user is normal user only show dashboard panel and hide admin panel navigation. Similarly for super admin show both dashboard and admin panel navigation.

Super Admin Preview:
![super admin](https://user-images.githubusercontent.com/15843175/75560232-e26d4080-5a6c-11ea-9bed-c04ab57bd15e.gif)


Admin Preview:
![Screenshot from 2020-02-28 20-56-01](https://user-images.githubusercontent.com/15843175/75560247-e9944e80-5a6c-11ea-8cd5-6d231e9806fc.png)


