### PR TITLE
LE-295: Handle Token Not Found in APP

### DIFF
--- a/app/src/constants/textConstants.js
+++ b/app/src/constants/textConstants.js
@@ -7,6 +7,7 @@ const textConstants = {
   ACCESS_TOKEN_EXPIRE: 'Access Token Unauthorized',
   USER_NOT_REGISTERED: 'User not registered',
   DELETE_WARNING_MESSAGE: 'Are you sure?',
+  TOKEN_NOT_FOUND: 'Token Not Found',
   DEFAULT_SLIDE_DURATION: 10,
   EMPTY_JSON: 'Empty JSON',
   UNAUTHORIZED_CODE: 401,

--- a/app/src/utils/httpUtil.js
+++ b/app/src/utils/httpUtil.js
@@ -103,7 +103,9 @@ axios.interceptors.response.use(
       ((error.response.status === textConstants.UNAUTHORIZED_CODE &&
         error.response.data.error.message === textConstants.REFRESH_TOKEN_EXPIRE) ||
         (error.response.status === textConstants.NOT_FOUND &&
-          error.response.data.error.message === textConstants.USER_NOT_REGISTERED))
+          error.response.data.error.message === textConstants.USER_NOT_REGISTERED) ||
+        (error.response.status === textConstants.NOT_FOUND &&
+          error.response.data.error.message === textConstants.TOKEN_NOT_FOUND))
     ) {
       bulletinUtil.logout();
     }


### PR DESCRIPTION
When a user is logged in, he gets redirected to the dashboard from login. But when the accessToken is expired and interceptor in APP uses the refresh token to get New accessToken at that point if RefreshToken is not found in API it throws Token not Found Error.

But Due to lack of handling of error For Token Not Found, the user gets stuck in the dashboard and unable to do perform any action.