### PR TITLE
fix-babel-cache: Add babel env in app start

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "REST API for the Bulletin-Board Kiosk application",
   "scripts": {
-    "start": "node dist/index.js",
+    "start": "BABEL_CACHE_PATH=/tmp/my-cache.json node dist/index.js",
     "codecov": "cat coverage/*/lcov.info | codecov",
     "seed": "knex seed:run --knexfile src/knexfile.js",
     "build": "rimraf dist && babel src -D --out-dir dist",


### PR DESCRIPTION
As being mono repo, babel didn't find the env preset for cache directory and API was always crashing.
With this the env for babel is provided on API start.